### PR TITLE
Bundle with external global BrowserFS

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,23 +1,16 @@
 {
-	"preset": "ts-jest/presets/default-esm",
-	"testEnvironment": "node",
-	"extensionsToTreatAsEsm": [
-		".ts"
-	],
-	"testMatch": [
-		"./**/*.test.ts"
-	],
+	"testMatch": ["<rootDir>/tests/**/*.(spec|test).ts"],
+	"extensionsToTreatAsEsm": [".ts"],
 	"moduleNameMapper": {
-		"^(\\.{1,2}/.*)\\.js$": "$1"
+		"^(\\.{1,2}/.*)\\.js$": "$1",
+		"^((?:fixtures|helpers|utils|mocks)/.*)\\.js$": "<rootDir>/tests/$1",
+		"^((?:app)/.*)\\.js$": "<rootDir>/src/$1",
+		"^(.*)\\.js$": ["<rootDir>/src/$1", "$1.js"],
+		"^(fixtures/.*)$": "<rootDir>/tests/$1"
 	},
-	"transform": {
-		"^.+\\.ts$": [
-			"ts-jest",
-			{
-				"tsconfig": "test/tsconfig.json",
-				"useESM": true
-			}
-		]
-	},
-	"verbose": true
+	"transformIgnorePatterns": ["/node_modules/(?!(@browserfs)/)"],
+	"transform": {"(\\.ts$|@browserfs)": ["ts-jest", {
+		"tsconfig": "<rootDir>/tests/tsconfig.json",
+		"useESM": true
+	}]}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.55.0",
 				"@typescript-eslint/parser": "^5.55.0",
 				"esbuild": "^0.17.18",
+				"esbuild-plugin-external-global": "^1.0.1",
 				"eslint": "^8.36.0",
 				"prettier": "^2.8.7",
 				"typedoc": "^0.25.1",
@@ -1196,6 +1197,12 @@
 				"@esbuild/win32-ia32": "0.17.18",
 				"@esbuild/win32-x64": "0.17.18"
 			}
+		},
+		"node_modules/esbuild-plugin-external-global": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz",
+			"integrity": "sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==",
+			"dev": true
 		},
 		"node_modules/eslint": {
 			"version": "8.36.0",
@@ -3193,6 +3200,12 @@
 				"@esbuild/win32-ia32": "0.17.18",
 				"@esbuild/win32-x64": "0.17.18"
 			}
+		},
+		"esbuild-plugin-external-global": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz",
+			"integrity": "sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==",
+			"dev": true
 		},
 		"eslint": {
 			"version": "8.36.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,612 @@
 {
 	"name": "@browserfs/fs-dom",
-	"version": "0.0.6",
+	"version": "0.0.7-iontach",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@browserfs/fs-dom",
-			"version": "0.0.6",
+			"version": "0.0.7-iontach",
 			"license": "MIT",
 			"dependencies": {
-				"@browserfs/core": "^0.1.0"
+				"@browserfs/core": "saoirse-iontach/browser-fs-core#semver:~0.1.1"
 			},
 			"devDependencies": {
+				"@types/jest": "^29.5.12",
 				"@typescript-eslint/eslint-plugin": "^5.55.0",
 				"@typescript-eslint/parser": "^5.55.0",
+				"cross-env": "^7.0.3",
 				"esbuild": "^0.17.18",
 				"esbuild-plugin-external-global": "^1.0.1",
 				"eslint": "^8.36.0",
+				"jest": "^29.7.0",
 				"prettier": "^2.8.7",
+				"ts-jest": "^29.1.2",
 				"typedoc": "^0.25.1",
-				"typescript": "5.2.2"
+				"typescript": "^5.2.2"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
+			"integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
+			"integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.24.1",
+				"@babel/parser": "^7.24.1",
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
+			"integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.24.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+			"integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-simple-access": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-split-export-declaration": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
+			"integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+			"integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+			"dev": true,
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+			"integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-typescript": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+			"integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+			"integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.24.1",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
 		"node_modules/@browserfs/core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@browserfs/core/-/core-0.1.0.tgz",
-			"integrity": "sha512-h+z0Hjw2awG29qo5wgxe/uMnLRpM/AvAq+m1nZtVnh6H8lenIQ4w1oUjyDCdlmp9p1SPdvfuQQegR+gXfCwhXQ==",
+			"version": "0.1.1-iontach",
+			"resolved": "git+ssh://git@github.com/saoirse-iontach/browser-fs-core.git#47eafb36a858ce763ce912386dfda88e9a7303a7",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^14.0.0",
 				"@types/readable-stream": "^4.0.10",
@@ -443,23 +1021,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/@eslint/eslintrc/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "13.20.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -487,12 +1048,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@eslint/js": {
 			"version": "8.36.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
@@ -516,29 +1071,6 @@
 				"node": ">=10.10.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -557,6 +1089,357 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
+		},
+		"node_modules/@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/console": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/core": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "^29.7.0",
+				"@jest/reporters": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-changed-files": "^29.7.0",
+				"jest-config": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-resolve-dependencies": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+			"dev": true,
+			"dependencies": {
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+			"dev": true,
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/globals": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"dev": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.1",
+				"strip-ansi": "^6.0.0",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.9"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/test-result": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/test-sequencer": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/test-result": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/transform": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"babel-plugin-istanbul": "^6.1.1",
+				"chalk": "^4.0.0",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pirates": "^4.0.4",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^4.0.2"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -593,6 +1476,114 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"dev": true
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"dev": true,
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.6.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+			"integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.20.7"
+			}
+		},
+		"node_modules/@types/graceful-fs": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "29.5.12",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+			"integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+			"dev": true,
+			"dependencies": {
+				"expect": "^29.0.0",
+				"pretty-format": "^29.0.0"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -617,6 +1608,27 @@
 			"version": "7.3.13",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"dev": true
+		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -652,29 +1664,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
 			"version": "7.5.4",
@@ -717,29 +1706,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.55.0",
@@ -784,29 +1750,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "5.55.0",
@@ -857,23 +1800,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -893,12 +1819,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.5.4",
@@ -1022,6 +1942,33 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1036,6 +1983,150 @@
 			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
 			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
 			"dev": true
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/babel-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/transform": "^29.7.0",
+				"@types/babel__core": "^7.1.14",
+				"babel-plugin-istanbul": "^6.1.1",
+				"babel-preset-jest": "^29.6.3",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.8.0"
+			}
+		},
+		"node_modules/babel-plugin-istanbul": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^5.0.4",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.12.3",
+				"@babel/parser": "^7.14.7",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/babel-plugin-jest-hoist": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.1.14",
+				"@types/babel__traverse": "^7.0.6"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/babel-preset-current-node-syntax": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/babel-preset-jest": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"dev": true,
+			"dependencies": {
+				"babel-plugin-jest-hoist": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
@@ -1084,6 +2175,59 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001587",
+				"electron-to-chromium": "^1.4.668",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"dependencies": {
+				"fast-json-stable-stringify": "2.x"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
 		"node_modules/buffer": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1107,6 +2251,12 @@
 				"ieee754": "^1.2.1"
 			}
 		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1116,17 +2266,257 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001600",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+			"dev": true
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"dev": true,
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/collect-v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"dev": true
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
+		"node_modules/create-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"prompts": "^2.0.1"
+			},
+			"bin": {
+				"create-jest": "bin/create-jest.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/dedent": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+			"dev": true,
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==",
 			"dev": true
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/diff-sequences": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -1159,6 +2549,39 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.4.721",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.721.tgz",
+			"integrity": "sha512-k1x2r6foI8iJOp+1qTxbbrrWMsOiHkzGBYwYigaq+apO1FSqtn44KTo3Sy69qt7CRr7149zTcsDvH7MUKsOuIQ==",
+			"dev": true
+		},
+		"node_modules/emittery": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/esbuild": {
@@ -1198,11 +2621,23 @@
 				"@esbuild/win32-x64": "0.17.18"
 			}
 		},
-		"node_modules/esbuild-plugin-external-global": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz",
-			"integrity": "sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==",
-			"dev": true
+		"node_modules/escalade": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/eslint": {
 			"version": "8.36.0",
@@ -1270,91 +2705,11 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/eslint/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/eslint/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
-		},
-		"node_modules/eslint/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/eslint/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/eslint/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/eslint/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/eslint/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -1433,15 +2788,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eslint/node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -1491,12 +2837,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/eslint/node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -1529,15 +2869,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eslint/node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1545,39 +2876,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/eslint/node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint/node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/eslint/node_modules/type-check": {
@@ -1590,21 +2888,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/eslint/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/espree": {
@@ -1643,6 +2926,19 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/esquery": {
@@ -1712,6 +3008,54 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/expect": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1767,6 +3111,15 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1786,6 +3139,19 @@
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1831,6 +3197,68 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1851,11 +3279,62 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
+		},
 		"node_modules/grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -1910,6 +3389,25 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/import-local": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+			"dev": true,
+			"dependencies": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			},
+			"bin": {
+				"import-local-fixture": "fixtures/cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1935,6 +3433,24 @@
 			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
 			"dev": true
 		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true
+		},
+		"node_modules/is-core-module": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1942,6 +3458,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/is-glob": {
@@ -1965,11 +3499,686 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-instrument": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+			"integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"dev": true,
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/core": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"import-local": "^3.0.2",
+				"jest-cli": "^29.7.0"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-changed-files": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^5.0.0",
+				"jest-util": "^29.7.0",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/esbuild-plugin-external-global": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz",
+			"integrity": "sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==",
+			"dev": true
+		},
+		"node_modules/eslint": {
+			"version": "8.36.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+			"dev": true
+		},
+		"node_modules/jest-circus": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+		"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"co": "^4.6.0",
+				"dedent": "^1.0.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^29.7.0",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"p-limit": "^3.1.0",
+				"pretty-format": "^29.7.0",
+				"pure-rand": "^6.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/core": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"create-jest": "^29.7.0",
+				"exit": "^0.1.2",
+				"import-local": "^3.0.2",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"yargs": "^17.3.1"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-config": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@jest/test-sequencer": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-jest": "^29.7.0",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"deepmerge": "^4.2.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"jest-circus": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"parse-json": "^5.2.0",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^29.6.3",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-docblock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"dev": true,
+			"dependencies": {
+				"detect-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-each": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-get-type": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/graceful-fs": "^4.1.3",
+				"@types/node": "*",
+				"anymatch": "^3.0.3",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.2.9",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.2"
+			}
+		},
+		"node_modules/jest-leak-detector": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+			"dev": true,
+			"dependencies": {
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"jest-resolve": "*"
+			},
+			"peerDependenciesMeta": {
+				"jest-resolve": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-pnp-resolver": "^1.2.2",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"resolve": "^1.20.0",
+				"resolve.exports": "^2.0.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"dev": true,
+			"dependencies": {
+				"jest-regex-util": "^29.6.3",
+				"jest-snapshot": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "^29.7.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"emittery": "^0.13.1",
+				"graceful-fs": "^4.2.9",
+				"jest-docblock": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-leak-detector": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-resolve": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/globals": "^29.7.0",
+				"@jest/source-map": "^29.6.3",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"cjs-module-lexer": "^1.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-snapshot": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@babel/generator": "^7.7.2",
+				"@babel/plugin-syntax-jsx": "^7.7.2",
+				"@babel/plugin-syntax-typescript": "^7.7.2",
+				"@babel/types": "^7.3.3",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^29.6.3",
+				"leven": "^3.1.0",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watcher": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+			"dev": true,
+			"dependencies": {
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"emittery": "^0.13.1",
+				"jest-util": "^29.7.0",
+				"string-length": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-util": "^29.7.0",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
 		},
 		"node_modules/js-sdsl": {
 			"version": "4.3.0",
@@ -1980,6 +4189,43 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -1993,10 +4239,64 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"node_modules/lodash.merge": {
@@ -2029,6 +4329,51 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"node_modules/makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
+			"dependencies": {
+				"tmpl": "1.0.5"
+			}
+		},
 		"node_modules/marked": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -2040,6 +4385,12 @@
 			"engines": {
 				"node": ">= 12"
 			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -2063,6 +4414,15 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2074,6 +4434,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -2087,6 +4453,39 @@
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
 		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+			"dev": true
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2094,6 +4493,21 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-limit": {
@@ -2111,6 +4525,42 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-locate/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2121,6 +4571,24 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -2141,6 +4609,27 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2151,6 +4640,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/prettier": {
@@ -2168,6 +4678,32 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -2175,6 +4711,35 @@
 			"engines": {
 				"node": ">= 0.6.0"
 			}
+		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pure-rand": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			]
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -2196,6 +4761,12 @@
 				}
 			]
 		},
+		"node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
 		"node_modules/readable-stream": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
@@ -2209,6 +4780,62 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve.exports": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/reusify": {
@@ -2249,6 +4876,36 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/shiki": {
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
@@ -2261,6 +4918,18 @@
 				"vscode-textmate": "^8.0.0"
 			}
 		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2268,6 +4937,43 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -2297,6 +5003,33 @@
 				}
 			]
 		},
+		"node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -2307,6 +5040,24 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -2321,11 +5072,64 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"node_modules/tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true
+		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2337,6 +5141,64 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/ts-jest": {
+			"version": "29.1.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+			"integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+			"dev": true,
+			"dependencies": {
+				"bs-logger": "0.x",
+				"fast-json-stable-stringify": "2.x",
+				"jest-util": "^29.0.0",
+				"json5": "^2.2.3",
+				"lodash.memoize": "4.x",
+				"make-error": "1.x",
+				"semver": "^7.5.3",
+				"yargs-parser": "^21.0.1"
+			},
+			"bin": {
+				"ts-jest": "cli.js"
+			},
+			"engines": {
+				"node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.0.0-beta.0 <8",
+				"@jest/types": "^29.0.0",
+				"babel-jest": "^29.0.0",
+				"jest": "^29.0.0",
+				"typescript": ">=4.3 <6"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"@jest/types": {
+					"optional": true
+				},
+				"babel-jest": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-jest/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/tslib": {
@@ -2358,6 +5220,15 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/type-fest": {
@@ -2430,6 +5301,36 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2448,6 +5349,20 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
 		"node_modules/vscode-oniguruma": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -2460,6 +5375,30 @@
 			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
 			"dev": true
 		},
+		"node_modules/walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"dependencies": {
+				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2469,11 +5408,83 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
+		},
+		"node_modules/write-file-atomic": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
@@ -2489,10 +5500,442 @@
 		}
 	},
 	"dependencies": {
+		"@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
+			"integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+			"dev": true
+		},
+		"@babel/core": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
+			"integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+			"dev": true,
+			"requires": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.24.1",
+				"@babel/parser": "^7.24.1",
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
+			"integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.24.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				}
+			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"dev": true
+		},
+		"@babel/helper-function-name": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.24.0"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+			"integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+			"dev": true
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"dev": true
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"dev": true
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
+			"integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+			"integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+			"integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.24.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+			"integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.24.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+			"integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.24.1",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/types": {
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
 		"@browserfs/core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@browserfs/core/-/core-0.1.0.tgz",
-			"integrity": "sha512-h+z0Hjw2awG29qo5wgxe/uMnLRpM/AvAq+m1nZtVnh6H8lenIQ4w1oUjyDCdlmp9p1SPdvfuQQegR+gXfCwhXQ==",
+			"version": "git+ssh://git@github.com/saoirse-iontach/browser-fs-core.git#47eafb36a858ce763ce912386dfda88e9a7303a7",
+			"from": "git+ssh://git@github.com/saoirse-iontach/browser-fs-core.git#47eafb36a858ce763ce912386dfda88e9a7303a7",
 			"requires": {
 				"@types/node": "^14.0.0",
 				"@types/readable-stream": "^4.0.10",
@@ -2691,15 +6134,6 @@
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"globals": {
 					"version": "13.20.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -2717,12 +6151,6 @@
 					"requires": {
 						"argparse": "^2.0.1"
 					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
 				}
 			}
 		},
@@ -2741,23 +6169,6 @@
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@humanwhocodes/module-importer": {
@@ -2771,6 +6182,284 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
+		},
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			}
+		},
+		"@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true
+		},
+		"@jest/console": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"slash": "^3.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^29.7.0",
+				"@jest/reporters": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-changed-files": "^29.7.0",
+				"jest-config": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-resolve-dependencies": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			}
+		},
+		"@jest/expect": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+			"dev": true,
+			"requires": {
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
+			}
+		},
+		"@jest/expect-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+			"dev": true,
+			"requires": {
+				"jest-get-type": "^29.6.3"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			}
+		},
+		"@jest/globals": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"dev": true,
+			"requires": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.1",
+				"strip-ansi": "^6.0.0",
+				"v8-to-istanbul": "^9.0.1"
+			}
+		},
+		"@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"requires": {
+				"@sinclair/typebox": "^0.27.8"
+			}
+		},
+		"@jest/source-map": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.9"
+			}
+		},
+		"@jest/test-result": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"slash": "^3.0.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.11.6",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"babel-plugin-istanbul": "^6.1.1",
+				"chalk": "^4.0.0",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pirates": "^4.0.4",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^4.0.2"
+			}
+		},
+		"@jest/types": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"dev": true,
+			"requires": {
+				"@jest/schemas": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			}
+		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2796,6 +6485,114 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@sinclair/typebox": {
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"dev": true
+		},
+		"@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+			"integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.20.7"
+			}
+		},
+		"@types/graceful-fs": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true
+		},
+		"@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"@types/jest": {
+			"version": "29.5.12",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+			"integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+			"dev": true,
+			"requires": {
+				"expect": "^29.0.0",
+				"pretty-format": "^29.0.0"
 			}
 		},
 		"@types/json-schema": {
@@ -2824,6 +6621,27 @@
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
 		},
+		"@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"dev": true,
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.55.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.55.0.tgz",
@@ -2842,21 +6660,6 @@
 				"tsutils": "^3.21.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"semver": {
 					"version": "7.5.4",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -2878,23 +6681,6 @@
 				"@typescript-eslint/types": "5.55.0",
 				"@typescript-eslint/typescript-estree": "5.55.0",
 				"debug": "^4.3.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@typescript-eslint/scope-manager": {
@@ -2917,23 +6703,6 @@
 				"@typescript-eslint/utils": "5.55.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@typescript-eslint/types": {
@@ -2963,15 +6732,6 @@
 					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"globby": {
 					"version": "11.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -2985,12 +6745,6 @@
 						"merge2": "^1.4.1",
 						"slash": "^3.0.0"
 					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
 				},
 				"semver": {
 					"version": "7.5.4",
@@ -3076,6 +6830,23 @@
 				"uri-js": "^4.2.2"
 			}
 		},
+		"ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.21.3"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+					"dev": true
+				}
+			}
+		},
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3087,6 +6858,119 @@
 			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
 			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
 			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"babel-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"dev": true,
+			"requires": {
+				"@jest/transform": "^29.7.0",
+				"@types/babel__core": "^7.1.14",
+				"babel-plugin-istanbul": "^6.1.1",
+				"babel-preset-jest": "^29.6.3",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"slash": "^3.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^5.0.4",
+				"test-exclude": "^6.0.0"
+			},
+			"dependencies": {
+				"istanbul-lib-instrument": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+					"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.12.3",
+						"@babel/parser": "^7.14.7",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.2.0",
+						"semver": "^6.3.0"
+					}
+				}
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.1.14",
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-current-node-syntax": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-jest-hoist": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -3118,6 +7002,36 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"browserslist": {
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001587",
+				"electron-to-chromium": "^1.4.668",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
+			}
+		},
+		"bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"requires": {
+				"fast-json-stable-stringify": "2.x"
+			}
+		},
+		"bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
 		"buffer": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -3127,10 +7041,94 @@
 				"ieee754": "^1.2.1"
 			}
 		},
+		"buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001600",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true
+		},
+		"ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true
+		},
+		"cjs-module-lexer": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+			"dev": true
+		},
+		"cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"dev": true
+		},
+		"collect-v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
 		"concat-map": {
@@ -3139,10 +7137,85 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
+		"create-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"prompts": "^2.0.1"
+			}
+		},
+		"cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"dedent": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+			"dev": true,
+			"requires": {}
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==",
+			"dev": true
+		},
+		"deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true
+		},
+		"detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -3169,6 +7242,33 @@
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.4.721",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.721.tgz",
+			"integrity": "sha512-k1x2r6foI8iJOp+1qTxbbrrWMsOiHkzGBYwYigaq+apO1FSqtn44KTo3Sy69qt7CRr7149zTcsDvH7MUKsOuIQ==",
+			"dev": true
+		},
+		"emittery": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"esbuild": {
@@ -3205,6 +7305,18 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz",
 			"integrity": "sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 			"dev": true
 		},
 		"eslint": {
@@ -3255,65 +7367,11 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
 				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
@@ -3365,12 +7423,6 @@
 						"type-fest": "^0.20.2"
 					}
 				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"is-path-inside": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3405,12 +7457,6 @@
 						"p-locate": "^5.0.0"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"optionator": {
 					"version": "0.9.1",
 					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -3434,41 +7480,11 @@
 						"p-limit": "^3.0.2"
 					}
 				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
 				"prelude-ls": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				},
 				"type-check": {
 					"version": "0.4.0",
@@ -3477,15 +7493,6 @@
 					"dev": true,
 					"requires": {
 						"prelude-ls": "^1.2.1"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -3521,6 +7528,12 @@
 					"requires": {}
 				}
 			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.5.0",
@@ -3571,6 +7584,42 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+		},
+		"execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+			"dev": true
+		},
+		"expect": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+			"dev": true,
+			"requires": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -3623,6 +7672,15 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"requires": {
+				"bser": "2.1.1"
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3639,6 +7697,16 @@
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
+			}
+		},
+		"find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
 			}
 		},
 		"flat-cache": {
@@ -3674,6 +7742,43 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
+		"fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"optional": true
+		},
+		"function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true
+		},
 		"glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3688,10 +7793,49 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
+		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
+		},
+		"html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true
 		},
 		"ieee754": {
@@ -3723,6 +7867,16 @@
 				}
 			}
 		},
+		"import-local": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			}
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3745,10 +7899,37 @@
 			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
 			"dev": true
 		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
+			"requires": {
+				"hasown": "^2.0.0"
+			}
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
 		"is-glob": {
@@ -3766,16 +7947,549 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true
+		},
+		"istanbul-lib-instrument": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+			"integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+					"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			}
+		},
+		"istanbul-reports": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"dev": true,
+			"requires": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			}
+		},
+		"jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+			"dev": true,
+			"requires": {
+				"@jest/core": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"import-local": "^3.0.2",
+				"jest-cli": "^29.7.0"
+			}
+		},
+		"jest-changed-files": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"dev": true,
+			"requires": {
+				"execa": "^5.0.0",
+				"jest-util": "^29.7.0",
+				"p-limit": "^3.1.0"
+			}
+		},
+		"jest-circus": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"co": "^4.6.0",
+				"dedent": "^1.0.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^29.7.0",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"p-limit": "^3.1.0",
+				"pretty-format": "^29.7.0",
+				"pure-rand": "^6.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			}
+		},
+		"jest-cli": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"dev": true,
+			"requires": {
+				"@jest/core": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"create-jest": "^29.7.0",
+				"exit": "^0.1.2",
+				"import-local": "^3.0.2",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"yargs": "^17.3.1"
+			}
+		},
+		"jest-config": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.11.6",
+				"@jest/test-sequencer": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-jest": "^29.7.0",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"deepmerge": "^4.2.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"jest-circus": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"parse-json": "^5.2.0",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			}
+		},
+		"jest-diff": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^29.6.3",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^3.0.0"
+			}
+		},
+		"jest-each": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"pretty-format": "^29.7.0"
+			}
+		},
+		"jest-environment-node": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"@types/graceful-fs": "^4.1.3",
+				"@types/node": "*",
+				"anymatch": "^3.0.3",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^2.3.2",
+				"graceful-fs": "^4.2.9",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"walker": "^1.0.8"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+			"dev": true,
+			"requires": {
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			}
+		},
+		"jest-mock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"requires": {}
+		},
+		"jest-regex-util": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-pnp-resolver": "^1.2.2",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"resolve": "^1.20.0",
+				"resolve.exports": "^2.0.0",
+				"slash": "^3.0.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"dev": true,
+			"requires": {
+				"jest-regex-util": "^29.6.3",
+				"jest-snapshot": "^29.7.0"
+			}
+		},
+		"jest-runner": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^29.7.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"emittery": "^0.13.1",
+				"graceful-fs": "^4.2.9",
+				"jest-docblock": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-leak-detector": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-resolve": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			}
+		},
+		"jest-runtime": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/globals": "^29.7.0",
+				"@jest/source-map": "^29.6.3",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"cjs-module-lexer": "^1.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			}
+		},
+		"jest-snapshot": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.11.6",
+				"@babel/generator": "^7.7.2",
+				"@babel/plugin-syntax-jsx": "^7.7.2",
+				"@babel/plugin-syntax-typescript": "^7.7.2",
+				"@babel/types": "^7.3.3",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+					"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			}
+		},
+		"jest-validate": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^29.6.3",
+				"leven": "^3.1.0",
+				"pretty-format": "^29.7.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+					"dev": true
+				}
+			}
+		},
+		"jest-watcher": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"emittery": "^0.13.1",
+				"jest-util": "^29.7.0",
+				"string-length": "^4.0.1"
+			}
+		},
+		"jest-worker": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"jest-util": "^29.7.0",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"js-sdsl": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
 			"integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -3790,10 +8504,49 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true
+		},
 		"jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true
+		},
+		"leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true
+		},
+		"lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true
+		},
+		"locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^4.1.0"
+			}
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -3825,10 +8578,51 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
+		"make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.5.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+					"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.5"
+			}
+		},
 		"marked": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
 			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"dev": true
+		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
 		"merge2": {
@@ -3847,6 +8641,12 @@
 				"picomatch": "^2.3.1"
 			}
 		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3855,6 +8655,12 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -3868,6 +8674,33 @@
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
 		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true
+		},
+		"node-releases": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+			"dev": true
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.0.0"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3875,6 +8708,15 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"p-limit": {
@@ -3886,6 +8728,32 @@
 				"yocto-queue": "^0.1.0"
 			}
 		},
+		"p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.2.0"
+			},
+			"dependencies": {
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				}
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3893,6 +8761,18 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
 			}
 		},
 		"path-exists": {
@@ -3907,11 +8787,44 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"dev": true
+		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			}
 		},
 		"prettier": {
 			"version": "2.8.7",
@@ -3919,15 +8832,56 @@
 			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
 			"dev": true
 		},
+		"pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"requires": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				}
+			}
+		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
 		},
+		"prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
+		"pure-rand": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"dev": true
+		},
 		"queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
+		},
+		"react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
 		"readable-stream": {
@@ -3941,6 +8895,44 @@
 				"process": "^0.11.10",
 				"string_decoder": "^1.3.0"
 			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			}
+		},
+		"resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^5.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true
+		},
+		"resolve.exports": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+			"dev": true
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -3962,6 +8954,27 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
 		"shiki": {
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
@@ -3974,11 +8987,54 @@
 				"vscode-textmate": "^8.0.0"
 			}
 		},
+		"signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true
+		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true
+		},
+		"stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			}
 		},
 		"string_decoder": {
 			"version": "1.3.0",
@@ -3995,6 +9051,27 @@
 				}
 			}
 		},
+		"string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"requires": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4004,16 +9081,66 @@
 				"ansi-regex": "^5.0.1"
 			}
 		},
+		"strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true
+		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true
+		},
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -4023,6 +9150,33 @@
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
+			}
+		},
+		"ts-jest": {
+			"version": "29.1.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+			"integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+			"dev": true,
+			"requires": {
+				"bs-logger": "0.x",
+				"fast-json-stable-stringify": "2.x",
+				"jest-util": "^29.0.0",
+				"json5": "^2.2.3",
+				"lodash.memoize": "4.x",
+				"make-error": "1.x",
+				"semver": "^7.5.3",
+				"yargs-parser": "^21.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+					"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"tslib": {
@@ -4039,6 +9193,12 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.20.2",
@@ -4084,6 +9244,16 @@
 			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
 			"dev": true
 		},
+		"update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"dev": true,
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -4101,6 +9271,17 @@
 				}
 			}
 		},
+		"v8-to-istanbul": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			}
+		},
 		"vscode-oniguruma": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -4113,16 +9294,88 @@
 			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
 			"dev": true
 		},
+		"walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.12"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
 		"word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true
 		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.7"
+			}
+		},
+		"y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"requires": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			}
+		},
+		"yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true
 		},
 		"yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
+		"esbuild-plugin-external-global": "^1.0.1",
 		"esbuild": "^0.17.18",
 		"eslint": "^8.36.0",
 		"prettier": "^2.8.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@browserfs/fs-dom",
-	"version": "0.0.6",
-	"description": "DOM backends for BrowserFS",
+	"version": "0.0.7-iontach",
+	"description": "DOM backends for @BrowserFS",
 	"main": "dist/index.js",
 	"types": "dist",
 	"keywords": [
@@ -10,15 +10,26 @@
 		"storage"
 	],
 	"type": "module",
-	"homepage": "https://github.com/browser-fs/fs-dom",
-	"author": "dr-vortex <jp@drvortex.dev>",
+	"homepage": "https://github.com/saoirse-iontach/browser-fs-dom",
+	"author": "John Vilk <jvilk@cs.umass.edu>",
+	"contributors": [
+		{
+			"name": "dr-vortex",
+			"email": "jp@drvortex.dev",
+			"url": "https://drvortex.dev"
+		},
+		{
+			"name": "saoirse-iontach",
+			"url": "https://github.com/saoirse-iontach"
+		}
+	],
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/browser-fs/fs-dom.git"
+		"url": "git+https://github.com/saoirse-iontach/browser-fs-dom.git"
 	},
 	"bugs": {
-		"url": "https://github.com/browser-fs/fs-dom/issues"
+		"url": "https://github.com/saoirse-iontach/browser-fs-dom/issues"
 	},
 	"engines": {
 		"node": ">= 18"
@@ -39,19 +50,24 @@
 		"lint": "eslint src",
 		"build": "node scripts/build.mjs",
 		"build:docs": "typedoc --out docs --name 'BrowserFS DOM' src/index.ts",
+		"test": "cross-env NODE_ENV=--experimental-vm-modules npx jest",
 		"prepublishOnly": "npm run build"
 	},
 	"devDependencies": {
+		"@types/jest": "^29.5.12",
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
 		"esbuild-plugin-external-global": "^1.0.1",
+		"cross-env": "^7.0.3",
 		"esbuild": "^0.17.18",
 		"eslint": "^8.36.0",
+		"jest": "^29.7.0",
 		"prettier": "^2.8.7",
+		"ts-jest": "^29.1.2",
 		"typedoc": "^0.25.1",
-		"typescript": "5.2.2"
+		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@browserfs/core": "^0.1.0"
+		"@browserfs/core": "saoirse-iontach/browser-fs-core#semver:~0.1.1"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,74 @@
-# BrowserFS DOM Backends
+# @BrowserFS / DOM Backends - iontach
 
-[BrowserFS](https://github.com/browser-fs/core) backends for DOM APIs. DOM APIs are *only* available natively in browsers.
+[@BrowserFS](https://github.com/saoirse-iontach/browser-fs-core) backends for DOM APIs. \
+DOM APIs are *only* available natively in browsers.
 
-Please read the BrowserFS documentation!
+**BrowserFS** is an in-browser file system that emulates the [Node JS file system API](http://nodejs.org/api/fs.html) and supports storing and retrieving files from various backends. BrowserFS also integrates nicely with other tools.
+
+> [!NOTE]
+> **@ZenFS** is an (breaking) update of **BrowserFS**, <ins>with a **node:fs**  interface</ins>. <sub>_As of April 2024, it is still in development, that's to say instable and not properly working (expectially encodings, with bad tests). More over contributors are actually dismissed. And **citation of original academic papers was sadly discarded...**_</sub>
+>
+> **@BrowserFS** is [transient](//github.com/browser-fs/NOTICE) project <sub>_from **BrowserFS** towards **@ZenFS**, (illegitimacy?) claiming to be the next **BrowserFS** (in fact it is **@ZenFS** before rebranding)_</sub>
+> [!IMPORTANT]
+> <ins>**@BrowserFS-iontach**</ins> is a bugfixed fork of **@BrowserFS @1.0**.
+> | Project        | author    | timeline          | links |
+> | -------------- | --------- | :---------------: | :---: |
+> | **BrowserFS**  | John Vilk | 2014 - 2017       | [npm](//www.npmjs.com/package/browserfs) [github](//github.com/jvilk/BrowserFS) |
+> | **@BrowserFS** | dr-Vortex | 09/2023 - 03/2024 | [npm](//www.npmjs.com/org/browserfs) [github](//github.com/browser-fs) |
+> | **@ZenFS**     | dr-Vortex | 03/2024 - ...     | [npm](//www.npmjs.com/org/zenfs) [github](//github.com/zen-fs) |
+> 
+> <sup>_dr-Vortext_ is an alias of _James P_</sup>
+### Citing
+
+BrowserFS is a component of the [Doppio](http://doppiojvm.org/) and [Browsix](https://browsix.org/) research projects from the PLASMA lab at the University of Massachusetts Amherst. If you decide to use BrowserFS in a project that leads to a publication, please cite the academic papers on [Doppio](https://dl.acm.org/citation.cfm?doid=2594291.2594293) and [Browsix](https://dl.acm.org/citation.cfm?id=3037727).
+
+<details><summary><i>citations</i></summary>
+
+  - > John Vilk and Emery D. Berger. Doppio: Breaking the Browser Language Barrier. In
+      *Proceedings of the 35th ACM SIGPLAN Conference on Programming Language Design and Implementation*
+      (2014), pp. 508–518.
+
+    <details><summary><i>references</i></summary>
+
+    ```bibtex
+    @inproceedings{VilkDoppio,
+        author	= {John Vilk and Emery D. Berger},
+        title	= {{Doppio: Breaking the Browser Language Barrier}},
+        booktitle	= {Proceedings of the 35th {ACM} {SIGPLAN} Conference
+        			on Programming Language Design and Implementation},
+        pages	= {508--518},
+        year	= {2014},
+        url	= {http://doi.acm.org/10.1145/2594291.2594293},
+        doi	= {10.1145/2594291.2594293}
+    }
+    ```
+    </details>
+
+  - > Bobby Powers, John Vilk, and Emery D. Berger. Browsix: Bridging the Gap Between Unix and the Browser.
+      In *Proceedings of the Twenty-Second International Conference on Architectural Support
+      for Programming Languages and Operating Systems* (2017), pp. 253–266.
+
+    <details><summary><i>references</i></summary>
+
+    ```bibtex
+    @inproceedings{PowersBrowsix,
+        author	= {Bobby Powers and John Vilk and Emery D. Berger},
+        title	= {{Browsix: Bridging the Gap Between Unix and the Browser}},
+        booktitle	= {Proceedings of the Twenty-Second International Conference
+        			on Architectural Support for Programming Languages and Operating Systems},
+        pages	= {253--266},
+        year	= {2017},
+        url	= {http://doi.acm.org/10.1145/3037697.3037727},
+        doi	= {10.1145/3037697.3037727}
+    }
+    ```
+
+    </details>
+</details>
+
+### License
+
+**BrowserFS** and **ZenFS** are licensed under the MIT License. See [LICENSE](license.md) for details.
 
 ## Backends
 
@@ -11,13 +77,24 @@ Please read the BrowserFS documentation!
 - `IndexedDB`: Stores files into an `IndexedDB` object database.
 - `WorkerFS`: Lets you mount the BrowserFS file system configured in the main thread in a WebWorker, or the other way around!
 
-For more information, see the [API documentation](https://browser-fs.github.io/fs-dom).
+For more information, see the [API documentation](https://saoirse-iontach.github.io/browser-fs-dom).
 
 ## Installing
 
 ```sh
-npm install @browserfs/fs-dom
+npm install saoirse-iontach/browser-fs-dom    # @browserfs/fs-dom
 ```
+
+#### Building
+
+-   Make sure you have Node and NPM installed. You must have Node v18 or newer.
+-   Install dependencies with `npm install`
+-   Build using `npm run build`
+-   You can find the built code in `dist`.
+
+#### Testing
+
+Run unit tests with `npm test`.
 
 ## Usage
 

--- a/tests/fixtures/data-bin-sm.ts
+++ b/tests/fixtures/data-bin-sm.ts
@@ -1,0 +1,22 @@
+/**
+ * intData:        ... < 128
+ * surrogateData:  0 or D8-DF
+ * mixedData:      0...255 including D8-DF
+ * randomData:     any
+ * (length of each data: 106 bytes)
+ */
+export const
+surrogateData: number[] = // 0 or D8-DF
+[ '',
+  'D800',        '00D9',
+  'DADB',        '00DCDE00',
+  'D8D9DA00',    '00DBDCDE',
+  'D8D9DADB',    '00DCDEDFD800',
+  'D8D9DADBDC00','00DEDFD8D9DA',
+  'D8D9DADBDCDE','00DFD8D9DADBDC00',
+  ''
+].join('0000'+'0000')
+ .match(/../g)?.map(x=>parseInt(x,16))||[],
+intData: number[] = Array.from(surrogateData, (v,i)=>i),
+mixedData: number[] = Array.from(surrogateData, (v,i)=>v||i*17&255),
+randomData: number[] = Array.from(surrogateData, (v,i)=>v||Math.random()*256|0);

--- a/tests/fixtures/data-bin-xl.ts
+++ b/tests/fixtures/data-bin-xl.ts
@@ -1,0 +1,219 @@
+export type randomdatablock = {
+    readonly indices: number[],
+    readonly buffer: ArrayBufferLike,
+    readonly u8array: Uint8Array,
+    readonly length: number
+  };
+  export const getRandomDatasetList = ()=> (
+    Object.entries(randomIndicies).map(([id,dataset]) => [String(id),
+      Object.entries(dataset).map(([id,indices]) => [Number(id), {
+        get indices(){ return indices.slice() },
+        get buffer(){ return getRandomData(indices).buffer },
+        get u8array(){ return getRandomData(indices) },
+        get length(){ return getRandomDataLength(indices) }
+      }])
+    ]) as [string, [number, randomdatablock][]][]
+  );
+  export const getRandomDataLength = (indices: number[])=> {
+    const chunks = indices.map(i => random256[i]);
+    const size = chunks.reduce((s,c)=> s += c.length, 0);
+    return size;
+  }
+  export const getRandomData = (indices: number[])=> {
+    const chunks = indices.map(i => random256[i]);
+    const size = chunks.reduce((s,c)=> s += c.length, 0);
+    const data = new Uint8Array(size);
+    chunks.reduce((o,c)=> o += (data.set(c,o), c.length), 0);
+    return data;
+  };
+  
+  /*
+    Random Data Lengths :
+    {
+      256:  [244,234,303,202,305,293,234,260,
+             302,246,263,221,216,242,280,254],
+      512:  [478,505,505,598,527,539,562,506,548,484],
+      768:  [750,718,738,849,756,776],
+      1024: [1015,953,983],
+      1536: [1348,1639,1518,1842],
+      2-4k: {
+        2048: 1963,
+        2304: 2218,
+        2816: 2828,
+        3328: 3366,
+        3840: 3855
+      }
+    }
+  */
+  export const randomIndicies: {[id:string]: {[id:number]: number[]}} = {
+    /* fixed number of chunks (1/2/3/4) */
+    256: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15].map(i=>[i]),
+    512: [[0,1],[2,3],[3,2],[4,5],[5,6],[6,4],[7,8],[7,9],[8,9],[10,11]],
+    768: [[9,0,7],[1,10,11],[12,13,14],[15,5,8],[13,15,7],[14,14,12]],
+    1024: [[1,5,9,13],[15,11,6,0],[12,3,8,10]],
+    /* variable number of chunks (5,2x6,7) */
+    1536: [[2,4,6,7,9],[0,1,2,5,8,10],[11,4,12,15,13,14],[9,8,7,6,5,4,3]],
+    /* long blocks (8,9,11,13,15) */
+    "2-4k": {
+      2048: [3,2,1,0,10,11,15,13],
+      2304: [12,14,14,13,12,15,10,11,9],
+      2816: [12,6,0,7,1,8,9,15,13,5,2],
+      3328: [14,4,6,5,11,9,3,4,10,15,2,0,12],
+      3840: [1,13,12,6,8,7,11,10, 2,5,15,3,9,4,14],
+    }
+  };
+  export const random256: number[][] =
+  ([[
+      "8f7c5c82a1f4c9802734af81eb50eb5a77c7c16bb45d6f73b4984925dd510e4e",
+      "0d151654d2b2810f5962e8557265d211983c9ec371bf222598d2d478cfed3923",
+      "59a4a716da50090dcedd7834bc7cc0c794042111f5bcfba004feca46d356d5bf",
+      "c2f368ad9e43a70799aa5359fabd5ebf0e3a26a243caaa4c00d4312edd536eea",
+      "4d6ace6dc6eda7ec50cd29bd1d38c2a9398779b62e021994cf90c9c1b9ef1678",
+      "1b1227cb48c027aceb3fee220777069e10bfcd101e5afdf97226c997c1e5ad22",
+      "5a3c38a84374e96e6307a002aaad4448be6f809076471cf676c5b701c0a18126",
+      "9ffb3402def175fbd44c9e2811ebbfac5a880095"
+    ],[
+      "366e3b9e59a9c3234d72d42db7ba96198ebfdf70ea6ed62b6ca57a25a5d153e7",
+      "1ca5b6bf34c1c7d8e164a0785beb11cd244813d81b314059d6353ed9980b2ac8",
+      "d096581405a81f4733d77198ffbaaa6e6e74263bdb5f026ad457b08a8446056b",
+      "98700da97890d3f685c4102ca40cb61cdfe50187bfc89a57432f9056075325b5",
+      "07b4bf30f7fa7b8de1a2ea54922b6499ced29bd82ff9f4ce344e86caeace1842",
+      "e6b79d13eef19888120139d354d0e6027043dc354695c06425884a8294ba26b0",
+      "f425496f74d5fd6346df9828062ae24935d47aa5daa7b45d7b811b90e5fe4b88",
+      "2106312d9770ec319825"
+    ],[
+      "bb313ae156246b1d3e8bf2c7797ebe2c5ab49faa7159bc5e0e65f64d94f7ff7d",
+      "a9d7b807a8f59f889fe2d681d200e825b610a18718de10377903f56aea39e9c1",
+      "487bda0daf42ea66a92334b03002fb9a4b8b3df62682ed81c1dc960527baff81",
+      "6769e6917a6353ee8b69afc6e53a4964c02cfa466e1d25cd3164494d23a957e3",
+      "2a94c2e95aa58d612e0881e8078acb987d33d23711701d9f826ad9b94c0df507",
+      "9585cae922cdfa176f2df7e0c55f1c5e799cb0fe7b53fe1d050c797852cb22a5",
+      "2c860febba7ac7c2bd3dd68b8fca42abbf6cb7b090c750b57aed57b0e7e3f56f",
+      "61ca188e996845b8e49cd79b668a1f3bcb9378a76dbbb581fb7e49f33f197d28",
+      "891a44168028b680e8bc8107ca9534dca9cf6e282e6478bddef78f68a44fbd7d",
+      "17979ef010b5da2feb0dc10905bbfe"
+    ],[
+      "0333bd86a915f798139c673003fe5cde0eccf1a279ece9909f1bcb2d0722df14",
+      "2beab507f5ae48da415ce6a536891415028e57449a1c1d4654cefa4561fddfa1",
+      "0081d2d55f3a322b513a74ad74352e0f542e8228c921ceea959c1bbdda1d2b9b",
+      "aae455a62d54c90fdb44af2ced044d1683f16be3391b9ddde80867fdcf885dcb",
+      "031ca47fa484d0964087bf065dc8125b84a6d80edbd0bc2199e198a236a92d3e",
+      "1f9393cb4cfcd1c6530853d4b84158a485493b42e52b00d81822cda3d179048e",
+      "b50d238fd025aa5a2ee4"
+    ],[
+      "6a56243b8f72c5c2c4377f202565a6850aaf2aa7dd5a28e6ad0e07fb09851e97",
+      "3b51e131e8ebd29df8befbcffe8e0b6344fbadc195783e7241a767370ae5368d",
+      "bdccea36a7d869476e171af8a384a6eace4fc3cbb44d4bed257b7c0fffd4ca45",
+      "c48b8caec650954d7144f63ef58ebf12caef5756dc3be759d19818522062114d",
+      "16cd8d61dcb837f0edfc3d511059e9509b1a8342f1ec3d36ca42b3dee24c7547",
+      "17b67c9f054fa220c5dd6befd9c4a559949351b196360adbe41f9a784f581bc8",
+      "693c30a3842717e8669fec30e8c9cd761b1898ba92ef6e5256b1455e76b80965",
+      "be8b716056404d2844ba59b07208df499013478173955fedf3ab2e08148240b3",
+      "c2254514d88239e38776221f2bcbf30e59e441ba8e5f64094f50b7eb59edb4a9",
+      "4b42574b51ac6fd589eebdd4bd4ff47ee2"
+    ],[
+      "ba909e03530b6257e298975ad0cb423d031bd2f482e70b0a1edc0b43982646d3",
+      "3f0af101f1e0257d6bb39fd6f0aba403c1d8ff4a0240c5d934ab48dec0e64d2a",
+      "9089673b3aa6eb4da1ff1c4c4ffa1f49656bafd44a5ce814f282f872d3802aab",
+      "b77934c207546c794561fb8a1e10e7419326c4689c14a326733088dc022f23c5",
+      "140c5546c90d1b59d6d3112a53fa46a3c35fac3b1a79bfafea8f6d5d8cb6322e",
+      "650601110709a322df3ec9781991e8bab823f25742f6e195b35055611142518b",
+      "bfcdaef5764bb5f9412b91ba727b64b31c6e05f1cde53b6aca73f05291fbf716",
+      "aeab2717f1e91ac6f6ec78fec70933b9056c0f0f630279beeb13922b4b98634c",
+      "de8f7ca4d3b507c158dafeb16adaa457c4dab9413a193891058159a0dbde3553",
+      "b8a3b2eac2"
+    ],[
+      "c526e1ef665f2b1e7600d8eac734d43a38efe173cac8b97b8989ef0b162c6807",
+      "b0da4d072e5a01d8caae75a5c72f17e6ef3bd58af482a0258877dc7c5ee9c762",
+      "6f7ee1f3917f32947de1922f363e8530aa5da5039a6a2006d86b5eea15a25b20",
+      "dff27e0baaf2a13351b5ebccc2333f54f7e1b2ccca8ceccfb758be47cec9ed86",
+      "2e73f93ba07baa1c0a36af3f5fab2639eb4309582f3b18fcf35e4cfc98922ebd",
+      "6ed955f6e4e2a74487258a227bf46acba3f4da90e6cfce4443b430763c3c195a",
+      "6927d08f9c1c87fce5a1d002f47d89c52e99e0a86f25cf3b7a1b6880ba5d9421",
+      "e0923a4ab6916bc96e8e"
+    ],[
+      "fac8b0d6881e8c92ece8502d8c69ea79f7eef7ad166434801984af022342c65d",
+      "28a7ebed786884eb3b9c0dcfdc7433b91a9e9a3404e6bbe9fd803cdb759b2cb5",
+      "1b96138021fce8feee26d099e803571acb94596a615874b9af57a0ac91597816",
+      "c0ffa5c8ba6a4fe2fc6fa1377a14a77d7ea2407e6e017ec02c93f50400cf4c68",
+      "ba6d4dd8dc72c8cbb84157ac4b82d790a600008cd0793e7a64297ee0768c8c51",
+      "342fa98decc12086dbafd7016595db2045ffa533b729ca962b31de974cb73713",
+      "dc5aa6e07e7559cd84ab314b335e68802c0106b5fc1757500c4979ece40b76af",
+      "644af3768bd6e7b727fce6d68ae3f33308cf4a79a4bea669ed0904d0acd9d544",
+      "42cae52b"
+    ],[
+      "e3f1f14dd7d9302139bbe22390ecbec5871898cb101e98a995cab9488abd9c81",
+      "fb1b4ea116d88d94a47bb205e3e2bbe88520acdd21cd47d3bbbb075008e7fa4f",
+      "2630732701572156829c44e452112a4d6fe8a7e5c4404d61ed525464abbce4ae",
+      "897b9bbab141921c674f5333dd6252e460a4d123b157a9f5a0d9bf444896b8af",
+      "1dcd53231b848df13ee6a7348751d2178c29964c133aeb4d0e9190621b899bb1",
+      "8c256fae024e00b64bae0419b5cca328b499538c3346fecaaee2b27213ff3938",
+      "5d24de36e72a1a940993540b686ffc26a78c13af9d67df39cb3aac0461aff838",
+      "70195db89f6bfca19214491936deac26dac1b7e87cddc7064ab4f23c79cb2ee8",
+      "8d7654aed629c8c2124dae1ea90a03a0b76502345ffa9f8b07eba44c65cca927",
+      "b2471452e47bc24ba91933f46f22"
+    ],[
+      "df18b88dc5ce49658d37c296739e92440b68a131f429f22699d9ac2f6a852770",
+      "d23f0f127f7458835d5a9a4d132d950aa7af733b714330ac205d91be2deb2807",
+      "b17ce9ae9798d3f8b7f961e932314d1c889e6ac888889b4f1ff6c0c94dcc187e",
+      "c13387ddfaab5cca56f62cc7e9a05292621ffeec8de6c378ae770ac2bcd01af7",
+      "8751df162164cdfdcc62abd4b416d2d8f582b21e887095c9d342d2e2625372e9",
+      "2f24b2a03dc9c34dc37c25a1a849ef66a1ea8550d7e8bb370d42f57c600c5650",
+      "044b923ddb162a1cd9b41aa7a8db157441af9174c9ead32538a62d8455d932a0",
+      "afc05b9c22ad5e60dffb3a1affc1fb2dd046c7fab137"
+    ],[
+      "2a75b00771ffb0096390ae5521952008fbb56a80fe74cf90c85d4b36e7a77e93",
+      "c233867f4b2ab0908aaabe1c6a631bcb6c714bed390eb22a44b4917f4ceadaa2",
+      "bc541ba58d854c638e6bc819eea8273b28b83f024be1b5e651a1130c4d186a3b",
+      "2f6a773cb6f2e7db09c2ecaa79047bff59a60c296cf6a346bdd852a81f35f499",
+      "82e3259ee4bbdf377718a61e30e754ae9725d18cbeaaca9dfff166816a5e3a3f",
+      "7758cb04d152a249efd17f0fb0b9d64074c011b4dab71da10d381aa3818d37d8",
+      "5aabad31204fe3be7c7ef792684c8e999cc4b076e9f7d83e2bd3e5096f180895",
+      "74d4153e20e9b52822625bbe6940425acbaca87adbff62e68a1ff7a166abcf47",
+      "ab953937b701cd"
+    ],[
+      "2d26095ddec3de842c89561571ef29cb010786e203e196e83355c00eaccc5011",
+      "091b97058fda754caafc6b5b970e75780ede3474477bb7625afcb083c9577922",
+      "5c15c5aebdf499c61644c4f2d1c9ec06a0878c3ae1c90c4d9189b4b7fc9d0c03",
+      "e2003a488d1c435689912d5f14465c5e9ad226e695d63412d872f2b6c1ec5f51",
+      "b45c2c0f0379d8898f41acdf57ce6f4dd9d1187565bf0374e844431c444d8b69",
+      "1940251f6af4ffae919f173d4b56d28992a0a1392bcc4f88b2dd7564784977f5",
+      "bd981a76723b2d1578c911d05cff2cb805feb42ee9e2d2934ab63d2096"
+    ],[
+      "a3b0d8e929ee41777040aff638e5a9eb6ae5f2fe91ce9c7ad41a14ece6b0efb6",
+      "4eb7eeedc4f58a1765ef18762a8c6c460907859e68741f0a496e121941c47e2e",
+      "9ea800d8444d529bdcf734185792bbf28b7fb4addfec6b1d2a5867f26d293915",
+      "6c70c60ae6f684cd2ea3448e72ac9d0355e59f0c3faa1e22a24b2557b85e75e2",
+      "db830d9edab5bd0d47e32cdcd6d005bcde6eaf1e863b31065b60253c12b8c9a0",
+      "881db467f4c18125b14ccfc51ef378fb73b9a1a383684f347b17228a544dc009",
+      "481ac86453b5f065984436c74c9c5ecc4bdc52556e431c15"
+    ],[
+      "602aefe40e33126473a035fbaaf7e4cea093f59d2b9cdbbee94d82949d9748f9",
+      "0702cda92d5902c78262a41ddcf2ab43df352c9afb1a7ba595892fb8b2a81a2d",
+      "d6a4a9f4469121e7ad90744647a57dd2a097a3241f03caf37e4af956f66d7379",
+      "7bc3bb6101ccf4831ae28f9cda84c379be6e043d86d869851f7894d5786ec6fb",
+      "6ce9fcd6a1e946586c5f9783139af47334d04046264549b13b321966b3333ad5",
+      "6130c9e9855ac9053e98a75a754abf1dc366a8715f072aee4d9d06f10ae2d2b0",
+      "60aee793f28c5f6da0698fcf7fb4230610e8ecc3f79656d0dade694a9d237fb2",
+      "3f96110b0bcbad26ced1e5e406770f8c3987"
+    ],[
+      "b746b96b90c31b8f81bcc3bcc415065aae72502b3eb39fd82c5ace30019baa46",
+      "c39b2bbb7e5361a5eb00cb89632a54fee2850e5576fffa09ef97e028c50db4d7",
+      "1552088e465f14f3cb6e9421972035c19e965b886d988c27f086091557034b38",
+      "c0b076f38db66d4de6cc032ffe203d939fa56cc8e55537c7f8550cd18d9f5da0",
+      "14157c15a0efd8235d2489192ca1cfbb49ffc467fd7e0d4e050fec24644d1789",
+      "3b7a3bbd2219796fc06d890a6dda028f2866c7093737729f4a84bbb0e0e8612d",
+      "b0703853109206095d37949d82d59f5381f567f4d909915ea237eb2536c9ec37",
+      "42444c00252fc10e2e4a753d576ac2dbc0f23db078a6b65405702d53f8b2f241",
+      "32716acbafb5a2efd4a0805badafee42a71a70f4e0054e06"
+    ],[
+      "ef43e541f5e514073674fef9dcc8e46ecc1350809a5945d9640511ba0d091831",
+      "63b8e6c4334535a38dbabe5e7b9e2e34c7727bb286f7c8682292a0023adbe292",
+      "c266efc7b42d2576f638fcd5c9dd70007b5a7da86eed4ed2c59c1693f769fca8",
+      "4f9b866553254868b1eba3c699583df6d0617f8f60b08569beafc4d575a3ee6c",
+      "687895b94a228c13ee97914aaa8ee35e66a848e8342e7961aba8564f8828445c",
+      "681639ace78d0cdc6b1ffddc5a24b73fe7a39b5c70aaa2c9df9822a51ebedb08",
+      "83f45e25807c574ae971a11e4d1cb23419cde23b39064c12a218c703fb801ca3",
+      "1397c670338a27a92886a067562fc9bbc82f420ee5489214bb72d28252ee"
+    ]
+  ]).map(a=>a.join('').match(/../g)?.map(x=>parseInt(x,16))||[]);

--- a/tests/fixtures/data-strings.ts
+++ b/tests/fixtures/data-strings.ts
@@ -1,0 +1,60 @@
+type KeyOfType<T, V> = keyof {[P in keyof T as T[P] extends V? P: never]};
+type Exports = typeof import('./data-strings.js');
+type Data = string | readonly number[];
+type dataset = 'bidiEncodings' | 'crossEncodings';
+type datakey = KeyOfType<Omit<Exports, dataset>, Data>;
+
+/**
+ * 8-bits data
+ */
+export const
+  data8 = Object.freeze(new Array(307).fill(0).map((_,i)=>17*i-3&255) as number[]),
+  data7 = Object.freeze(data8.map(i=>i&127)),
+  ascii = data7.flatMap(i=>String.fromCharCode(i)).join(''),
+  bin = data8.flatMap(i=>String.fromCharCode(i)).join(''),
+  hex = data8.flatMap(i=>i.toString(16).padStart(2,'0')).join(''),
+  b64 = btoa(bin),
+  b64url = b64.replaceAll('+','-').replaceAll('/','_').replaceAll('=','');
+
+/**
+ * unicode data
+ */
+const
+  isSurrogate = (i:number)=> i>>11 === 27,
+  toSupplementary = (i:number)=> (i&15)+1 << 16 | i,
+  u16toUtf32 = (i:number)=> isSurrogate(i)? toSupplementary(i) : i;
+export const
+  data16 = Object.freeze(new Array(256*256).fill(0).map((_,i)=>17*i-3&0xffff) as number[]),
+  unicode = data16.map(u16toUtf32).flatMap(i=>String.fromCodePoint(i)).join(''),
+  utf8 = Object.freeze(Array.from(new TextEncoder().encode(unicode))),
+  utf16 = Object.freeze(unicode.split('').map(c=>c.charCodeAt(0))),
+  utf16be = Object.freeze(utf16.flatMap(i=>[i>>8,i&255])),
+  utf16le = Object.freeze(utf16.flatMap(i=>[i&255,i>>8])),
+  utf16as8 = Object.freeze(utf16.map(i=>i&255));
+
+export const bidiEncodings = [
+    ['ascii',     ascii,  data7],
+    ['latin1',    bin,    data8],
+    ['binary',    bin,    data8],
+    ['hex',       hex,    data8],
+    ['base64',    b64,    data8],
+    ['base64url', b64url, data8],
+    /* ---------------------- */
+    ['utf8',      unicode, utf8],
+    ['utf-8',     unicode, utf8],
+    ['utf16le',   unicode, utf16le],
+    ['utf-16le',  unicode, utf16le],
+    ['ucs2',      unicode, utf16le],
+    ['ucs-2',     unicode, utf16le],
+] as [BufferEncoding, string, readonly number[]][];
+
+export const crossEncodings = [
+    'encode(unicode, "ascii")  => utf16as8',
+    'encode(unicode, "latin1") => utf16as8',
+    'encode(unicode, "binary") => utf16as8',
+    'decode(data8,   "ascii")  => ascii',
+    'encode(b64,     "base64url") => data8',
+    'encode(b64url,  "base64")    => data8',
+].map(s=>s.split(/\W+/)) as (
+    ['encode'|'decode', datakey, BufferEncoding, datakey][]
+);

--- a/tests/helpers/bufferDataTests.helper.ts
+++ b/tests/helpers/bufferDataTests.helper.ts
@@ -1,0 +1,89 @@
+import * as fixtures from 'fixtures/data-strings.js';
+import * as smallbin from 'fixtures/data-bin-sm.js';
+import {getRandomDatasetList} from 'fixtures/data-bin-xl.js';
+import {equals} from 'utils/bufferDataEquality.util.js';
+
+const {bidiEncodings, crossEncodings} = fixtures;
+
+export function writeAndReadBackTests(
+    write:(name:string, data:Uint8Array)=>void,
+    read:(name:string)=>Uint8Array
+){
+    let starts = 0;
+    let success = 0;
+    beforeAll(()=>{starts = success = 0});
+
+    test.each(Object.entries(smallbin))(
+        'writeAndReadBack %s', (label, data)=>{
+            starts++;
+
+            write(label, Uint8Array.from(data));
+            const input = Uint8Array.from(data);
+            const ouput = read(label);
+
+            expect(ouput).toEqual(input);
+            success++;
+        }
+    );
+
+    test('writeAndReadBack RandomData', ()=>{
+        expect(success).toBe(starts);
+        let label = "";
+        for(const [groupId, group] of getRandomDatasetList())
+        for(const [datasetId, dataset] of group)
+        try {
+            label = `${groupId}.${datasetId}`;
+
+            write(label, dataset.u8array);
+            const input = dataset.u8array;
+            const ouput = read(label);
+
+            expect(equals(ouput, input)).toBe(true);
+        }
+        catch (err) {
+            err.message = `${label}: ${err.message}`;
+            throw err;
+        }
+    });
+};
+
+export function encodingTests(
+    encode:(data:string, encoding:BufferEncoding)=>Uint8Array,
+    decode:(data:Uint8Array, encoding:BufferEncoding)=>string
+){
+
+    function u8array(array:readonly number[]) {
+        return Uint8Array.from(array);
+    }
+
+    describe('bidirectional encodings', ()=>{
+        describe.each(bidiEncodings)(
+            '%s', (encoding, string, data)=>{
+
+                test('encode', ()=>{ expect(equals(
+                    encode(string, encoding), u8array(data)
+                )).toBe(true) });
+
+                test('decode', ()=>{ expect(equals(
+                    decode(u8array(data), encoding), string
+                )).toBe(true) });
+            }
+        );
+    });
+
+    describe('cross encodings', ()=>{
+        const fn = {encode,decode};
+        const get = (key:string, value?:any)=>(
+            value = fixtures[key],
+            typeof value === 'string' ? value : u8array(value)
+        );
+        test.each(crossEncodings)(
+            '%s(%s, "%s") => %s',
+            (name, input, encoding, expected)=>{
+                expect(equals(
+                    fn[name](get(input) as any, encoding), get(expected)
+                )).toBe(true);
+            }
+        );
+    });
+};

--- a/tests/mocks/Storage.mock.ts
+++ b/tests/mocks/Storage.mock.ts
@@ -1,0 +1,79 @@
+export default class MockedStorage implements Storage {
+
+    #store: {[key:string]: Uint8Array};
+    static readonly #storeFns = ['clear', 'getItem', 'setItem', 'removeItem'];
+
+    constructor() {
+        /* init, mock, freeze, disable oldstyled api */
+        this.clear();
+        for(const k of MockedStorage.#storeFns) this[k] = jest.fn(this[k]);
+        Object.freeze(this);
+        return new Proxy(this, MockedStorage.#handler);
+    }
+
+    /* Forbid full read */
+    get length():number {
+        throw new Error('Method not implemented.');
+    }
+    key(index: number): string {
+        throw new Error('Method not implemented.');
+    }
+
+    /* Implement well defined Storage API */
+    clear():void {
+        this.#store = {};
+    }
+    getItem(key: string): string {
+        if (!Object.hasOwn(this.#store, key)) return null;
+        return new TextDecoder().decode(this.#store[key]);
+    }
+    setItem(key: string, value: string): void {
+        this.#store[key] = new TextEncoder().encode(value);
+    }
+    removeItem(key: string): void {
+        delete this.#store[key];
+    }
+
+    static {
+        this.prototype[Symbol.toStringTag] = 'Storage';
+    }
+
+    /* Forbid legacy dict object api */
+    static #target = Symbol();
+    static {
+        const proto = this.prototype;
+        const callable:ProxyHandler<Function> = {
+            apply: (t,o,a)=> Reflect.apply(t,o[MockedStorage.#target]||o,a)
+        };
+        for(const k of MockedStorage.#storeFns) {
+            proto[k] = new Proxy(proto[k], callable);
+        }
+    }
+    static #handler:ProxyHandler<MockedStorage> = {
+        has: (t,p)=>{
+            if (p === MockedStorage.#target) return true;
+            if (Reflect.has(t,p)) return true;
+            throw new Error('Method not implemented.');
+        },
+        get: (t,p,r)=>{
+            if (p === MockedStorage.#target) return t;
+            if (Reflect.has(t,p)) return Reflect.get(t,p,r);
+            throw new Error('Method not implemented.');
+        },
+        set: (t,p,v,r)=>{
+            if (Reflect.has(t,p)) return Reflect.set(t,p,v,r);
+            throw new Error('Method not implemented.');
+        },
+        getOwnPropertyDescriptor: (t,p)=>{
+            if (Reflect.has(t,p)) return Reflect.getOwnPropertyDescriptor(t,p);
+            throw new Error('Method not implemented.');
+        },
+        ownKeys: ()=>{
+            throw new Error('Method not implemented.');
+        },
+    }
+
+    static unmocked(instance:MockedStorage) {
+        return instance[MockedStorage.#target] as Storage;
+    }
+}

--- a/tests/specs/StorageStore.spec.ts
+++ b/tests/specs/StorageStore.spec.ts
@@ -1,0 +1,29 @@
+import {StorageStore} from 'backends/Storage.js';
+import MockedStorage from 'mocks/Storage.mock.js';
+import {writeAndReadBackTests} from 'helpers/bufferDataTests.helper.js';
+
+/*
+    file.js: getMount('/') insteadof this._fs
+
+      shared.ts import from '../file.js';
+      file.js   import from './emulation/shared.js';
+
+      at Object.<anonymous> (node_modules/@browserfs/core/dist/backends/InMemory.js:38:41)
+      at Object.<anonymous> (node_modules/@browserfs/core/dist/emulation/shared.js:5:1)
+      at Object.<anonymous> (node_modules/@browserfs/core/dist/file.js:3:1)
+      at Object.<anonymous> (node_modules/@browserfs/core/dist/backends/SyncStore.js:4:1)
+      at Object.<anonymous> (src/backends/Storage.ts:1:1)
+      at Object.<anonymous> (tests/specs/StorageStore.spec.ts:1:1)
+*/
+
+describe('StorageStore', ()=>{
+    let mock = null, store = null;
+    beforeEach(()=>{
+        mock = new MockedStorage();
+        store = new StorageStore(mock);
+    });
+    writeAndReadBackTests(
+        (name, data)=> store.put(name, data, false),
+        (name)=> store.get(name)
+    );
+});

--- a/tests/specs/browser-min.spec.ts
+++ b/tests/specs/browser-min.spec.ts
@@ -1,0 +1,32 @@
+import * as expected from 'index.js';
+import {readFileSync} from 'node:fs';
+import vm = require('node:vm');
+
+const ctxOptions:vm.CreateContextOptions = {
+    codeGeneration: {strings: false, wasm: false},
+    microtaskMode: 'afterEvaluate'
+}
+const runOptions:vm.RunningScriptOptions = {
+    timeout: 500,
+    microtaskMode: 'afterEvaluate'
+}
+test('browser.min.js', ()=>{
+    const path = require.resolve('/../dist/browser.min.js');
+    const src = readFileSync(path, 'utf8');
+    const context:any = {TextEncoder, TextDecoder};
+
+    vm.createContext(context, ctxOptions);
+    vm.runInContext(src, context, {filename: 'browser.min.js', ...runOptions});
+    expect(context.BrowserFS_DOM).toBeDefined();
+
+    let name;
+    for(name in expected)
+    try {
+        expect(typeof(context.BrowserFS_DOM[name]))
+            .toBe(typeof(expected[name]));
+    }
+    catch (err) {
+        err.message = `${name}: ${err.message}`
+        throw err;
+    }
+})

--- a/tests/specs/core-EncodeDecode.spec.ts
+++ b/tests/specs/core-EncodeDecode.spec.ts
@@ -1,0 +1,17 @@
+import {encode, decode} from '@browserfs/core/utils.js';
+import {encodingTests} from 'helpers/bufferDataTests.helper.js';
+
+// witness test 
+describe('node:Buffer', ()=>{
+    const bufAsArr = (b:Buffer)=>new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+
+    encodingTests(
+        (str:string, encoding:BufferEncoding)=> bufAsArr(Buffer.from(str, encoding)),
+        (arr:Uint8Array, encoding:BufferEncoding)=> Buffer.from(arr).toString(encoding)
+    );
+});
+
+// core test
+describe('core encode/decode', ()=>{
+    encodingTests(encode, decode);
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "../",
+		"paths": {
+			"fixtures/*": ["tests/fixtures/*"],
+			"helpers/*": ["tests/helpers/*"],
+			"utils/*": ["tests/utils/*"],
+			"mocks/*": ["tests/mocks/*"],
+			"app/*": ["src/*"],
+			"*": ["src/*"]
+		},
+		"allowJs": true
+	},
+	"include": ["../src/**/*", "../tests/**/*"]
+}

--- a/tests/utils/bufferDataEquality.util.ts
+++ b/tests/utils/bufferDataEquality.util.ts
@@ -1,0 +1,24 @@
+/**
+ * Check equality of data related to read/write/Buffer operations
+ */
+export function equals<T = string|Uint8Array>(a:T, b:T):boolean {
+    if (a === b) return true;
+    if (!(a && b)) return false; // filter null/undefined
+    if (Object.getPrototypeOf(a) !== Uint8Array.prototype) return false;
+    if (Object.getPrototypeOf(b) !== Uint8Array.prototype) return false;
+    // if string, then we know they are not equals...
+    // if other type, then we don't care...
+    // ... and so we have return false
+
+    // now we have to check Uint8Array equality
+    const arrA = a as Uint8Array;
+    const arrB = b as Uint8Array;
+
+    if (arrA.byteLength !== arrB.byteLength) return false;
+    for (let i = 0; i < arrA.byteLength; i++) {
+        if (arrA[i] !== arrB[i]) return false;
+    }
+    return true;
+}
+
+export default equals;


### PR DESCRIPTION
For an unknown reason, bundle doesn't respect order of class declarations and references.
Furthermore the bundle include lot of core modules, resulting in an unnecessary extra size.

So this fix resolve @zenfs/core modules as external global ZenFS instead of inlining.

Fix #1 