### PR TITLE
fix(IndexdDB): Availability test never closes

### DIFF
--- a/src/IndexedDB.ts
+++ b/src/IndexedDB.ts
@@ -154,7 +154,10 @@ async function testAvailability(idbFactory: IDBFactory): Promise<boolean> {
 	try {
 		const req = idbFactory.open('__zenfs_test');
 
-		await wrap(req);
+		const db = await wrap(req);
+		// Make sure the test db gets closed so that other zenfs instances in other workers don't get blocked
+		db.close();
+
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
I currently have a use case where I'm using ZenFS in multiple workers. The first worker to initiate will run the availability test, but since it never closes its connection to the database, it blocks the other instances from starting.