### PR TITLE
Fix for `WebAccess` data corruption caused by append and positional writes

### DIFF
--- a/src/access.ts
+++ b/src/access.ts
@@ -210,10 +210,10 @@ export class WebAccessFS extends Async(IndexFS) {
 			return;
 		}
 
-		const writable = await handle.createWritable();
+		const writable = await handle.createWritable({ keepExistingData: true });
 
 		try {
-			await writable.seek(offset);
+			if (offset < inode.size) await writable.seek(offset);
 		} catch {
 			await writable.write({ type: 'seek', position: offset });
 		}


### PR DESCRIPTION
- Summary This PR resolves a critical data loss issue in the WebAccess (OPFS) backend where 'append' or 'positional write' operations could overwrite existing data due to a lack of persistence during stream creation and misalignment of the seek pointer.
- Changes
1. Enabled 'keepExistingData: true' in 'createWritable()' to prevent the browser from truncating the file upon opening the write stream.
2. Introduced conditional 'seek()': The explicit seek is only performed if the target offset is within the existing file bounds. For append operations, we rely on the browser's native pointer management to ensure atomic-like consistency.
- Technical Note This dual-approach addresses both the physical truncation issue and the logical offset mismatch between the VFS inode metadata and the underlying OPFS storage state.