### PR TITLE
Preload in two requests, not one per record

### DIFF
--- a/src/IndexedDB.ts
+++ b/src/IndexedDB.ts
@@ -48,6 +48,19 @@ export class IndexedDBTransaction extends Transaction<IndexedDBStore> {
 		return data;
 	}
 
+	/**
+	 * Fill the store's cache with every record, in two requests rather than one per record.
+	 * @internal
+	 */
+	public async preload(): Promise<void> {
+		// Both iterate in ascending key order, so the results line up index for index.
+		const [keys, values] = await Promise.all([wrap(this._idb.getAllKeys()), wrap(this._idb.getAll())]);
+		for (let i = 0; i < keys.length; i++) {
+			const data: Uint8Array | undefined = values[i];
+			if (data) this.store.cache.set(Number(keys[i]), data);
+		}
+	}
+
 	public getSync(id: number, offset: number, end?: number): Uint8Array | undefined {
 		if (!this.store.cache.has(id)) return;
 		const data = new Uint8Array(this.store.cache.get(id)!);
@@ -193,10 +206,7 @@ const _IndexedDB = {
 			log.notice('Async preloading disabled for IndexedDB');
 			return fs;
 		}
-		const tx = store.transaction();
-		for (const id of await tx.keys()) {
-			await tx.get(id); // Adds to cache
-		}
+		await store.transaction().preload();
 		return fs;
 	},
 } as const satisfies Backend<StoreFS<IndexedDBStore>, IndexedDBOptions>;

--- a/tests/indexeddb.test.ts
+++ b/tests/indexeddb.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+import 'fake-indexeddb/auto';
+
+import { configureSingle, fs } from '@zenfs/core';
+import { IndexedDB } from '@zenfs/dom/IndexedDB.js';
+import assert from 'node:assert/strict';
+import { after, suite, test } from 'node:test';
+
+after(() => indexedDB.deleteDatabase('preload'));
+
+suite('IndexedDB', () => {
+	test('reopening a store preloads every record', async () => {
+		await configureSingle({ backend: IndexedDB, storeName: 'preload' });
+		await fs.promises.mkdir('/dir');
+
+		const written = new Map<string, number[]>();
+		for (let i = 0; i < 64; i++) {
+			const contents = Array.from<number>({ length: 1 + ((i * 37) % 512) }).fill(i);
+			await fs.promises.writeFile(`/dir/file${i}`, new Uint8Array(contents));
+			written.set(`/dir/file${i}`, contents);
+		}
+		await fs.promises.writeFile('/dir/empty', new Uint8Array());
+
+		// Reading synchronously only works if create() filled the cache.
+		await configureSingle({ backend: IndexedDB, storeName: 'preload' });
+		for (const [path, contents] of written) assert.deepEqual(Array.from(fs.readFileSync(path)), contents);
+		assert.deepEqual(Array.from(fs.readFileSync('/dir/empty')), []);
+	});
+});


### PR DESCRIPTION
# Preload in two requests, not one per record

`@zenfs/dom` · `IndexedDB`

`IndexedDB.create()` warmed `StoreFS`'s sync cache with one `IDBRequest` per record:

```ts
const tx = store.transaction();
for (const id of await tx.keys()) {
    await tx.get(id); // Adds to cache
}
```

Each is awaited before the next is issued. The cost is not the bytes — it is N serialised round trips
through the transaction's event queue, and N is the number of files in the store. It is paid on every
open, before the filesystem is usable.

`getAllKeys()` and `getAll()` answer the same question in **two** requests. Both iterate the store in
ascending key order and both run on the one transaction, so the results line up index for index and
need no second lookup to pair them.

Preloading a 500-file store goes from **1,005 requests to 2**, by the script below.

That script counts requests rather than timing them: `fake-indexeddb` has no IPC, so the cost this
removes does not show up as time there. In a browser each of those requests is a real round trip
through the transaction's event queue, which is where the time goes.

<details>
<summary><b>Measurement</b> — minimal, no third-party code</summary>

`fake-indexeddb` is already a devDependency here. Save this as `repro.js` in a fresh clone and run
`npm install && npm run build && node repro.js`. The cache also has to come out right, or the request
count means nothing.

```js
import 'fake-indexeddb/auto';
import { configureSingle, fs } from '@zenfs/core';
import { IndexedDB } from '@zenfs/dom/IndexedDB.js';

// A store with some files in it.
await configureSingle({ backend: IndexedDB, storeName: 'bench' });
await fs.promises.mkdir('/dir');
const expected = new Map();
for (let i = 0; i < 500; i++) {
    const contents = new Uint8Array(1 + ((i * 37) % 512)).fill(i);
    await fs.promises.writeFile(`/dir/file${i}`, contents);
    expected.set(`/dir/file${i}`, Array.from(contents));
}

// Count the requests the preload issues when the store is reopened.
let requests = 0;
for (const method of ['get', 'getAll', 'getAllKeys', 'openCursor']) {
    const original = IDBObjectStore.prototype[method];
    IDBObjectStore.prototype[method] = function (...args) {
        requests++;
        return original.apply(this, args);
    };
}

const reopened = await IndexedDB.create({ storeName: 'bench' });
console.log('records in the store:', reopened.store.cache.size);
console.log('IDB requests to preload them:', requests);

// And the cache has to be right, or the request count means nothing.
await configureSingle({ backend: IndexedDB, storeName: 'bench' });
const wrong = [...expected].filter(([path, contents]) => String(Array.from(fs.readFileSync(path))) !== String(contents));
console.log('files whose contents came back wrong:', wrong.length);
```

Against `main`:

```
records in the store: 1004
IDB requests to preload them: 1005
files whose contents came back wrong: 0
```

Against this branch:

```
records in the store: 1004
IDB requests to preload them: 2
files whose contents came back wrong: 0
```

</details>

<details>
<summary><b>Tests</b></summary>

Nothing exercised this before. `setup-idb.ts` calls `configureSingle` and only then `copyAsync(data)`,
so `preload()` has always run against an empty store and the loop body never executed — putting a
`throw` in it leaves all four suites green.

`tests/indexeddb.test.ts` writes 64 files and an empty one, reopens the store and reads them back
**synchronously**. That only works if `create()` filled the cache, and only returns the right bytes if
each key was paired with its own value. Reversing the key order fails it; so does skipping the fill.

</details>

<details>
<summary><b>Notes for review</b></summary>

- The values are no longer copied on the way in, unlike `get()`. Each is already a fresh structured
  clone that nothing else holds a reference to, so the copy only doubled the peak memory of the
  largest allocation this backend makes. `store.cache` is private to `IndexedDB.ts` — `getSync`
  re-copies with `new Uint8Array(...)`, which respects `byteOffset` — so nothing downstream can tell.
- `getAll()` materialises every value in one response where the loop made N small ones. If you would
  rather bound that, batching over `IDBKeyRange` with a `count` keeps the same shape.
- `store.transaction()` opens `readwrite` for what is a read-only preload. That predates this change,
  so I left it, but `readonly` would be more correct and would not block other holders.
- `IndexedDBTransaction.keys()` is now unused internally. It is part of core's `Transaction` API, so
  it stays.
- `disableAsyncCache` is untouched: it still returns before any of this.

</details>

---

Co-authored with Claude Opus 5; the commit carries a `Co-Authored-By` trailer for it.
